### PR TITLE
chore(docker): Add docker and docker-compose support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+# Avoid copy of config files with secrets
+.env
+config.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:14-alpine
+
+WORKDIR /usr/src/app
+
+COPY . ./
+
+RUN apk --no-cache add g++ gcc libgcc libstdc++ linux-headers make python3
+
+RUN yarn global add --quiet node-gyp
+
+RUN yarn
+
+RUN yarn build
+
+CMD [ "yarn", "start" ]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,16 @@
+version: "3"
+
+services:
+  fpo-node:
+    build: "."
+    image: fluxprotocol/fpo-node:dev
+    container_name: fpo-node
+    environment:
+      - EVM_PRIVATE_KEY=${EVM_PRIVATE_KEY}
+      - NEAR_NO_LOGS=${NEAR_NO_LOGS}
+      - DEBUG=${DEBUG}
+      - ENABLE_ANALYTICS=${ENABLE_ANALYTICS}
+      - NEAR_CREDENTIALS_STORE_PATH=/usr/src/app/.near-credentials
+    volumes:
+      - ./config.json:/usr/src/app/config.json
+      - ~/.near-credentials:/usr/src/app/.near-credentials


### PR DESCRIPTION
This PR adds basic support for using Docker and `docker-compose`.

To build and run the docker image (from project folder):

```console
docker build . -t fluxprotocol/fpo-node:dev

docker run -d \
    --name fpo_node \
    --volume /PROJECT_FOLDER/config.json:/usr/src/app/config.json \
    --volume /PROJECT_FOLDER/.env:/usr/src/app/.env \
    --volume /home/USER/.near-credentials:/home/USER/.near-credentials \
    fluxprotocol/fpo-node:dev
```

It assumes that the `.env` NEAR credentials are pointing to `/home/USER/.near-credentials`.

To run the docker container using `docker-compose` tool (from project folder):
```console
docker-compose up
```

It assumes that NEAR credentials are located under `/home/USER/.near-credentials`.

Both, `config.json` and `.env` are not included into the Docker container on purpose as they contain private keys.