### PR TITLE
feat: Add healthcheck service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,16 @@ FROM node:14-alpine
 
 WORKDIR /usr/src/app
 
-COPY . ./
+# Copy only required files
+COPY package.json package.json
+COPY yarn.lock yarn.lock
+COPY tsconfig.json tsconfig.json
+COPY src/ src/
 
-RUN apk --no-cache add g++ gcc libgcc libstdc++ linux-headers make python3
-
-RUN yarn global add --quiet node-gyp
+# Install curl for checking container health with `curl`
+RUN apk --no-cache add curl
 
 RUN yarn
-
 RUN yarn build
 
 CMD [ "yarn", "start" ]

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "private": false,
     "scripts": {
         "test": "jest",
-        "start": "yarn build && node 'dist/src/main.js' start",
+        "dev": "yarn build && node 'dist/src/main.js'",
+        "start": "node 'dist/src/main.js'",
         "build": "tsc -p ."
     },
     "dependencies": {
@@ -17,6 +18,7 @@
         "bn.js": "^5.2.0",
         "dotenv": "^15.0.0",
         "ethers": "^5.5.4",
+        "express": "^4.17.3",
         "jsonpath-plus": "^6.0.1",
         "lodash.topath": "^4.5.2",
         "near-api-js": "^0.44.2",
@@ -26,6 +28,7 @@
     },
     "devDependencies": {
         "@types/big.js": "^6.1.2",
+        "@types/express": "^4.17.13",
         "@types/jest": "^27.4.0",
         "@types/lodash.topath": "^4.5.6",
         "@types/node": "^17.0.14",

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,3 +27,6 @@ export const ENABLE_TELEGRAM_NOTIFICATIONS = process.env.ENABLE_TELEGRAM_NOTIFIC
 export const TELEGRAM_BOT_API = process.env.TELEGRAM_BOT_TOKEN ? `https://api.telegram.org/bot${process.env.TELEGRAM_BOT_TOKEN}` : "";
 export const TELEGRAM_ALERTS_CHAT_ID = process.env.TELEGRAM_ALERTS_CHAT_ID;
 export const TELEGRAM_STATS_CHAT_ID = process.env.TELEGRAM_STATS_CHAT_ID;
+
+export const HEALTHCHECK_ENABLED = process.env.HEALTHCHECK_ENABLED === 'true';
+export const HEALTHCHECK_PORT = process.env.HEALTHCHECK_PORT ?? '80';

--- a/src/healthCheck/Healthcheck.ts
+++ b/src/healthCheck/Healthcheck.ts
@@ -1,0 +1,42 @@
+import logger from "../services/LoggerService";
+import express from "express";
+
+export interface HealthcheckConfig {
+    enabled: boolean;
+    port: number;
+}
+
+export class Healthcheck {
+    static type = "Healthcheck";
+    config: HealthcheckConfig;
+
+    constructor(healthcheckConfig: HealthcheckConfig) {
+        this.config = healthcheckConfig;
+    }
+
+    async start(): Promise<boolean> {
+        if (this.config.enabled) {
+            const app = express();
+            app.get('/healthcheck', (_req, res) => {
+                const healthcheck = {
+                    message: 'OK',
+                    timestamp: Date.now(),
+                    uptime: process.uptime()
+                };
+
+                try {
+                    res.send(healthcheck);
+                } catch (e) {
+                    healthcheck.message = `Error: ${e}`;
+                    res.status(503).send();
+                }
+            })
+
+            app.listen(this.config.port, () => {
+                logger.info(`[${Healthcheck.type}] Service listening on port ${this.config.port}`)
+            });
+        }
+
+        return this.config.enabled;
+    }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,8 @@ async function main() {
         const didModuleBootFail = moduleBootResults.some(isStarted => isStarted === false);
         if (didModuleBootFail) throw new Error(`Failed to boot due a module issue`);
 
+        await appConfig.healthcheck.start();
+
         logger.info(`🚀 Booted`);
     } catch (error) {
         logger.error(`${error}`);


### PR DESCRIPTION
This PR includes the implementation of a healthcheck service, e.g. to be used while running as Docker containers.

- Add endpoint to `localhost/healthcheck` (port 80)
- Refine Dockerfile by removing unnecessary steps and installing `curl`